### PR TITLE
Update CLI usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,22 +29,22 @@ You can use the patterns as indicated via the website:
 
 You can install patternfills via npm like so:
 
-`npm install patternfills`
+`npm install -g patternfills`
 
 It comes with an executable that will allow you to produce the CSS classes or the SVG classes and save them to an appropriate file. This might come in handy when you want to integrate patternfills into
 your build process.
 
 To produce either the css or svg you can run:
 
-`./bin/patternfills --format=svg|css`
+`patternfills --format=svg|css`
 
 You can provide a destination like so
 
-`./bin/patternfills --format=svg|css --dest=your/path`
+`patternfills --format=svg|css --dest=your/path`
 
 And even point to a different pattern set like this:
 
-`./bin/patternfills --format=svg|css --source=your/patterns`
+`patternfills --format=svg|css --source=your/patterns`
 
 ## How do patterns work?
 

--- a/public/index.html
+++ b/public/index.html
@@ -155,10 +155,18 @@
       Yep! If you'd like to use Pattern Fills in your application. You can install patternfills via npm like so:
     </p>
 
-    <p><code>npm install patternfills</code></p>
+    <p><code>npm install --save patternfills</code></p>
+
+    <h2>Can I use these from the command line?</h2>
 
     <p>
-      It comes with an executable that will allow you to produce the CSS classes or the SVG classes and save them to an appropriate file. This might come in handy when you want to integrate patternfills into
+      You betcha! If you'd like to use Pattern Fills from the command line, you can install the library globally via npm like so:
+    </p>
+
+    <p><code>npm install -g patternfills</code></p>
+
+    <p>
+      The executable will allow you to produce the CSS classes or the SVG classes and save them to an appropriate file. This might come in handy when you want to integrate patternfills into
       your build process.
     </p>
 
@@ -168,13 +176,13 @@
         <li>
           To produce either the css or svg you can run:
           <br>
-          <code>./bin/patternfills --format=svg|css</code>
+          <code>patternfills --format=svg|css</code>
         </li>
         <li>
           You can provide an alternate source pattern directory. This is
           optional.
           <br>
-          <code>./bin/patternfills --format=svg|css --source=your/patterns</code>
+          <code>patternfills --format=svg|css --source=your/patterns</code>
           <br>
           You'll want to follow a similar folder organization scheme to ours, so
           be sure to look at <code>src/patterns</code>.
@@ -183,7 +191,7 @@
         <li>
           You can provide a destination file path. Otherwise your output will be piped to <code>stdout</code>.
           <br>
-          <code>./bin/patternfills --format=svg|css --dest=your/path</code>
+          <code>patternfills --format=svg|css --dest=your/path</code>
         </li>
       </ul>
     </p>


### PR DESCRIPTION
The instructions currently document a "local" npm installation but
describe CLI invocation as though the installed package is included in
the user's PATH environmental variable. This is an invalid assumption in
most cases and will not generally work as expected.

The most common way for end users to consume this project as a binary is
to install it globally. Update the installation instructions to use the
global approach, and simplify the ussage examples accordingly.

(Local installation is possible but far less common. Users needing that
level of control can reasonably be expected to know how to re-interpret
the instructions in that case.)