### PR TITLE
updating to jsdom 11, which doesn't need contextify

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "commander": "^2.6.0",
     "d3": "~3.5.6",
     "ent": "^2.0.0",
-    "jsdom": "3.1.2",
+    "jsdom": "~11.0",
     "underscore": "~1.5.2"
   },
   "devDependencies": {

--- a/src/pattern_builder.js
+++ b/src/pattern_builder.js
@@ -44,7 +44,7 @@ PatternBuilder.prototype.getSinglePatternData = function(patternGroupName, patte
   b64 = "data:image/svg+xml;base64," + b64;
 
   // make a mock node with d3 for the pattern, and get its dimensions.
-  var document = jsdom.jsdom(),
+  var document = new jsdom.JSDOM().window.document,
       mockNode = d3.select(document.body).html(pattern);
 
   var height = mockNode.select("svg").attr("height");


### PR DESCRIPTION
Installing patterfills on modern node (>6) is very hard because jsdom < 4.x depends on [contextify](https://github.com/brianmcd/contextify), which won't compile in OSX or Windows (AFAIK, or at least with much trouble).

I updated jsdom to the 11.x.y major with the corresponding changes in the code (which are minimal) and now it installs (and runs) perfectly in OSX. It'll probably do it too on Windows and Linux.

Cheers!